### PR TITLE
Fix checkstyle error due to removal of GenericHID

### DIFF
--- a/src/main/java/frc/robot/TeleopInput.java
+++ b/src/main/java/frc/robot/TeleopInput.java
@@ -1,7 +1,6 @@
 package frc.robot;
 
 // WPILib Imports
-import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.Joystick;
 
 /**


### PR DESCRIPTION
WPILib project importer deleted the GenericHID usage in Joystick.
Fix the checkstyle error due to the now unnecessary import.